### PR TITLE
License project under MPL2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/PBot/AntiFlood.pm
+++ b/PBot/AntiFlood.pm
@@ -7,6 +7,10 @@
 # The nickserv/ban-evasion stuff probably ought to be in BanTracker or some
 # such suitable class.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::AntiFlood;
 
 use warnings;

--- a/PBot/BanTracker.pm
+++ b/PBot/BanTracker.pm
@@ -6,6 +6,10 @@
 #
 # Does NOT do banning or unbanning.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::BanTracker;
 
 use warnings;

--- a/PBot/BlackList.pm
+++ b/PBot/BlackList.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Manages list of hostmasks that are not allowed to join a channel.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::BlackList;
 
 use warnings;

--- a/PBot/BotAdminCommands.pm
+++ b/PBot/BotAdminCommands.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Administrative command subroutines.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::BotAdminCommands;
 
 use warnings;

--- a/PBot/BotAdmins.pm
+++ b/PBot/BotAdmins.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Manages list of bot admins and whether they are logged in.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::BotAdmins;
 
 use warnings;

--- a/PBot/ChanOpCommands.pm
+++ b/PBot/ChanOpCommands.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Channel operator command subroutines.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::ChanOpCommands;
 
 use warnings;

--- a/PBot/ChanOps.pm
+++ b/PBot/ChanOps.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Provides channel operator status tracking and commands.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::ChanOps;
 
 use warnings;

--- a/PBot/Channels.pm
+++ b/PBot/Channels.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Manages list of channels and auto-joins.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Channels;
 
 use warnings;

--- a/PBot/Commands.pm
+++ b/PBot/Commands.pm
@@ -6,6 +6,10 @@
 #          Registered items will then be executed if their command name matches
 #          a name provided via input.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Commands;
 
 use warnings;

--- a/PBot/DualIndexHashObject.pm
+++ b/PBot/DualIndexHashObject.pm
@@ -4,6 +4,10 @@
 # Purpose: Provides a hash-table object with an abstracted API that includes 
 # setting and deleting values, saving to and loading from files, etc.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::DualIndexHashObject;
 
 use warnings;

--- a/PBot/EventDispatcher.pm
+++ b/PBot/EventDispatcher.pm
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::EventDispatcher;
 
 use warnings;

--- a/PBot/FactoidCommands.pm
+++ b/PBot/FactoidCommands.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Administrative command subroutines.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::FactoidCommands;
 
 use warnings;

--- a/PBot/FactoidModuleLauncher.pm
+++ b/PBot/FactoidModuleLauncher.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Handles forking and execution of module processes
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::FactoidModuleLauncher;
 
 use warnings;

--- a/PBot/Factoids.pm
+++ b/PBot/Factoids.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Provides functionality for factoids and a type of external module execution.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Factoids;
 
 use warnings;

--- a/PBot/HashObject.pm
+++ b/PBot/HashObject.pm
@@ -4,6 +4,10 @@
 # Purpose: Provides a hash-table object with an abstracted API that includes 
 # setting and deleting values, saving to and loading from files, etc.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::HashObject;
 
 use warnings;

--- a/PBot/IRCHandlers.pm
+++ b/PBot/IRCHandlers.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Subroutines to handle IRC events
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::IRCHandlers;
 
 use warnings;

--- a/PBot/IgnoreList.pm
+++ b/PBot/IgnoreList.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Manages ignore list.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::IgnoreList;
 
 use warnings;

--- a/PBot/IgnoreListCommands.pm
+++ b/PBot/IgnoreListCommands.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Bot commands for interfacing with ignore list.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::IgnoreListCommands;
 
 use warnings;

--- a/PBot/Interpreter.pm
+++ b/PBot/Interpreter.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: 
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Interpreter;
 
 use warnings;

--- a/PBot/LagChecker.pm
+++ b/PBot/LagChecker.pm
@@ -4,6 +4,10 @@
 # Purpose: sends PING command to IRC server and times duration for PONG reply in
 # order to maintain lag history and average.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::LagChecker;
 
 use warnings;

--- a/PBot/Logger.pm
+++ b/PBot/Logger.pm
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Logger;
 
 use warnings;

--- a/PBot/MessageHistory.pm
+++ b/PBot/MessageHistory.pm
@@ -7,6 +7,10 @@
 # Used in conjunction with AntiFlood and Quotegrabs for kick/ban on
 # flood/ban-evasion and grabbing quotes, respectively.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::MessageHistory;
 
 use warnings;

--- a/PBot/MessageHistory_SQLite.pm
+++ b/PBot/MessageHistory_SQLite.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: SQLite backend for storing/retreiving a user's message history
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::MessageHistory_SQLite;
 
 use warnings;

--- a/PBot/NickList.pm
+++ b/PBot/NickList.pm
@@ -5,6 +5,10 @@
 # Used to retrieve list of channels a nick is present in or to 
 # determine if a nick is present in a channel.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::NickList;
 
 use warnings;

--- a/PBot/PBot.pm
+++ b/PBot/PBot.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: IRC Bot (3rd generation)
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # $Id$
 
 package PBot::PBot;

--- a/PBot/Plugins.pm
+++ b/PBot/Plugins.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Loads and manages plugins.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Plugins;
 
 use warnings;

--- a/PBot/Plugins/AntiAway.pm
+++ b/PBot/Plugins/AntiAway.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Kicks people that visibly auto-away with ACTIONs or nick-changes
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Plugins::AntiAway;
 
 use warnings;

--- a/PBot/Plugins/AntiKickAutoRejoin.pm
+++ b/PBot/Plugins/AntiKickAutoRejoin.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Temporarily bans people who immediately auto-rejoin after a kick.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Plugins::AntiKickAutoRejoin;
 
 use warnings;

--- a/PBot/Plugins/AntiRepeat.pm
+++ b/PBot/Plugins/AntiRepeat.pm
@@ -1,3 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 package PBot::Plugins::AntiRepeat;
 

--- a/PBot/Plugins/AntiTwitter.pm
+++ b/PBot/Plugins/AntiTwitter.pm
@@ -4,6 +4,10 @@
 # Purpose: Warns people off from using @nick style addressing. Temp-bans if they
 #          persist.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Plugins::AntiTwitter;
 
 use warnings;

--- a/PBot/Plugins/AutoRejoin.pm
+++ b/PBot/Plugins/AutoRejoin.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Auto-rejoin channels after kick or whatever.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Plugins::AutoRejoin;
 
 use warnings;

--- a/PBot/Plugins/Counter.pm
+++ b/PBot/Plugins/Counter.pm
@@ -1,3 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 package PBot::Plugins::Counter;
 

--- a/PBot/Plugins/Quotegrabs.pm
+++ b/PBot/Plugins/Quotegrabs.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Allows users to "grab" quotes from message history and store them for later retrieval.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Plugins::Quotegrabs;
 
 use warnings;

--- a/PBot/Plugins/Quotegrabs/Quotegrabs_Hashtable.pm
+++ b/PBot/Plugins/Quotegrabs/Quotegrabs_Hashtable.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Hashtable backend for storing and retreiving quotegrabs
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Plugins::Quotegrabs::Quotegrabs_Hashtable;
 
 use warnings;

--- a/PBot/Plugins/Quotegrabs/Quotegrabs_SQLite.pm
+++ b/PBot/Plugins/Quotegrabs/Quotegrabs_SQLite.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: SQLite back-end for storing and retreiving quotegrabs
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Plugins::Quotegrabs::Quotegrabs_SQLite;
 
 use warnings;

--- a/PBot/Plugins/UrlTitles.pm
+++ b/PBot/Plugins/UrlTitles.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Display titles of URLs in channel messages.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Plugins::UrlTitles;
 
 use warnings;

--- a/PBot/Plugins/_Example.pm
+++ b/PBot/Plugins/_Example.pm
@@ -1,3 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 package PBot::Plugins::_Example;
 

--- a/PBot/Refresher.pm
+++ b/PBot/Refresher.pm
@@ -4,6 +4,10 @@
 # Purpose: Refreshes/reloads module subroutines. Does not refresh/reload
 # module member data, only subroutines.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Refresher;
 
 use warnings;

--- a/PBot/Registerable.pm
+++ b/PBot/Registerable.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Provides functionality to register and execute one or more subroutines.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Registerable;
 
 use warnings;

--- a/PBot/Registry.pm
+++ b/PBot/Registry.pm
@@ -4,6 +4,10 @@
 # Purpose: Provides a centralized registry of configuration settings that can
 # easily be examined and updated via set/unset commands without restarting.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Registry;
 
 use warnings;

--- a/PBot/RegistryCommands.pm
+++ b/PBot/RegistryCommands.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Commands to introspect and update Registry
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::RegistryCommands;
 
 use warnings;

--- a/PBot/SQLiteLogger.pm
+++ b/PBot/SQLiteLogger.pm
@@ -4,6 +4,10 @@
 # Purpose: Logs SQLite trace messages to Logger.pm with profiling of elapsed
 # time between messages.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::SQLiteLogger;
 
 use strict;

--- a/PBot/SQLiteLoggerLayer.pm
+++ b/PBot/SQLiteLoggerLayer.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: PerlIO::via layer to log DBI trace messages
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::SQLiteLoggerLayer;
 
 use strict;

--- a/PBot/SelectHandler.pm
+++ b/PBot/SelectHandler.pm
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::SelectHandler;
 
 use warnings;

--- a/PBot/StdinReader.pm
+++ b/PBot/StdinReader.pm
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::StdinReader;
 
 use warnings;

--- a/PBot/Timer.pm
+++ b/PBot/Timer.pm
@@ -5,6 +5,10 @@
 #
 # Caveats: Uses ALARM signal and all its issues.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package PBot::Timer;
 
 use warnings;

--- a/PBot/Utils/ParseDate.pm
+++ b/PBot/Utils/ParseDate.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/PBot/VERSION.pm
+++ b/PBot/VERSION.pm
@@ -3,6 +3,10 @@
 #
 # Purpose: Keeps track of bot version.
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # $Id$
 
 package PBot::VERSION;

--- a/build/update-version.pl
+++ b/build/update-version.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/acronym.pl
+++ b/modules/acronym.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # quick and dirty by :pragma
 
 use LWP::UserAgent;

--- a/modules/ago.pl
+++ b/modules/ago.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use Time::Duration;
 
 my ($ago) = @ARGV;

--- a/modules/c11std.pl
+++ b/modules/c11std.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/c2english.pl
+++ b/modules/c2english.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/c2english/CGrammar.pm
+++ b/modules/c2english/CGrammar.pm
@@ -1,6 +1,10 @@
 # C-to-English Grammar
 # Pragmatic Software
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 {
   my ($rule_name, @macros, @typedefs, @identifiers); 
 }

--- a/modules/c2english/c2eng.pl
+++ b/modules/c2english/c2eng.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use strict;
 use warnings;
 

--- a/modules/c99std.pl
+++ b/modules/c99std.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/cdecl.pl
+++ b/modules/cdecl.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # quick and dirty by :pragma
 
 my $command = join(' ', @ARGV);

--- a/modules/cfaq.pl
+++ b/modules/cfaq.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 my $match = 1;
 my $matches = 0;
 my $found = 0;

--- a/modules/cjeopardy/IRCColors.pm
+++ b/modules/cjeopardy/IRCColors.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/cjeopardy/QStatskeeper.pm
+++ b/modules/cjeopardy/QStatskeeper.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package QStatskeeper;
 
 use warnings;

--- a/modules/cjeopardy/Scorekeeper.pm
+++ b/modules/cjeopardy/Scorekeeper.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package Scorekeeper;
 
 use warnings;

--- a/modules/cjeopardy/cjeopardy.pl
+++ b/modules/cjeopardy/cjeopardy.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/cjeopardy/cjeopardy_answer.pl
+++ b/modules/cjeopardy/cjeopardy_answer.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/cjeopardy/cjeopardy_filter.pl
+++ b/modules/cjeopardy/cjeopardy_filter.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/cjeopardy/cjeopardy_hint.pl
+++ b/modules/cjeopardy/cjeopardy_hint.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/cjeopardy/cjeopardy_qstats.pl
+++ b/modules/cjeopardy/cjeopardy_qstats.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/cjeopardy/cjeopardy_scores.pl
+++ b/modules/cjeopardy/cjeopardy_scores.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/cjeopardy/cjeopardy_show.pl
+++ b/modules/cjeopardy/cjeopardy_show.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/codepad.pl
+++ b/modules/codepad.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_block.pl
+++ b/modules/compiler_block.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # compiler_client.pl connects to compiler_server.pl hosted at PeerAddr/PeerPort below
 # and sends a nick, language and code, then retreives and prints the compilation/execution output.
 #

--- a/modules/compiler_client.pl
+++ b/modules/compiler_client.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # compiler_client.pl connects to compiler_server.pl hosted at PeerAddr/PeerPort below
 # and sends a nick, language and code, then retreives and prints the compilation/execution output.
 #

--- a/modules/compiler_vm/Diff.pm
+++ b/modules/compiler_vm/Diff.pm
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 package Diff;
 
 use strict;

--- a/modules/compiler_vm/cc
+++ b/modules/compiler_vm/cc
@@ -1,3 +1,6 @@
 #!/bin/sh
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 CC_LOCAL=1 ./compiler_vm_client.pl c99 compiler compiler "$@"

--- a/modules/compiler_vm/compiler_client.pl
+++ b/modules/compiler_vm/compiler_client.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # compiler_client.pl connects to compiler_server.pl hosted at PeerAddr/PeerPort below
 # and sends a nick, language and code, then retreives and prints the compilation/execution output.
 #

--- a/modules/compiler_vm/compiler_server.pl
+++ b/modules/compiler_vm/compiler_server.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/compiler_server_vbox_win32.pl
+++ b/modules/compiler_vm/compiler_server_vbox_win32.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/compiler_server_watchdog.pl
+++ b/modules/compiler_vm/compiler_server_watchdog.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/compiler_vm_client.pl
+++ b/modules/compiler_vm/compiler_vm_client.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/compiler_vm_server.pl
+++ b/modules/compiler_vm/compiler_vm_server.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/compiler_watchdog.pl
+++ b/modules/compiler_vm/compiler_watchdog.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/_c_base.pm
+++ b/modules/compiler_vm/languages/_c_base.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 use feature "switch";

--- a/modules/compiler_vm/languages/_default.pm
+++ b/modules/compiler_vm/languages/_default.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 use feature "switch";

--- a/modules/compiler_vm/languages/bash.pm
+++ b/modules/compiler_vm/languages/bash.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/bc.pm
+++ b/modules/compiler_vm/languages/bc.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/bf.pm
+++ b/modules/compiler_vm/languages/bf.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/c11.pm
+++ b/modules/compiler_vm/languages/c11.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/c89.pm
+++ b/modules/compiler_vm/languages/c89.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/c99.pm
+++ b/modules/compiler_vm/languages/c99.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/clang.pm
+++ b/modules/compiler_vm/languages/clang.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/clang11.pm
+++ b/modules/compiler_vm/languages/clang11.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/clang89.pm
+++ b/modules/compiler_vm/languages/clang89.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/clang99.pm
+++ b/modules/compiler_vm/languages/clang99.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/clangpp.pm
+++ b/modules/compiler_vm/languages/clangpp.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/clisp.pm
+++ b/modules/compiler_vm/languages/clisp.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/cpp.pm
+++ b/modules/compiler_vm/languages/cpp.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/freebasic.pm
+++ b/modules/compiler_vm/languages/freebasic.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/go.pm
+++ b/modules/compiler_vm/languages/go.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/haskell.pm
+++ b/modules/compiler_vm/languages/haskell.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/java.pm
+++ b/modules/compiler_vm/languages/java.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/javascript.pm
+++ b/modules/compiler_vm/languages/javascript.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/ksh.pm
+++ b/modules/compiler_vm/languages/ksh.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/lua.pm
+++ b/modules/compiler_vm/languages/lua.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/perl.pm
+++ b/modules/compiler_vm/languages/perl.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/python.pm
+++ b/modules/compiler_vm/languages/python.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/python3.pm
+++ b/modules/compiler_vm/languages/python3.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/qbasic.pm
+++ b/modules/compiler_vm/languages/qbasic.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/scheme.pm
+++ b/modules/compiler_vm/languages/scheme.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/_c_base.pm
+++ b/modules/compiler_vm/languages/server/_c_base.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/_default.pm
+++ b/modules/compiler_vm/languages/server/_default.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 use feature "switch";

--- a/modules/compiler_vm/languages/server/c11.pm
+++ b/modules/compiler_vm/languages/server/c11.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/c89.pm
+++ b/modules/compiler_vm/languages/server/c89.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/c99.pm
+++ b/modules/compiler_vm/languages/server/c99.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/clang.pm
+++ b/modules/compiler_vm/languages/server/clang.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/clang11.pm
+++ b/modules/compiler_vm/languages/server/clang11.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/clang89.pm
+++ b/modules/compiler_vm/languages/server/clang89.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/clang99.pm
+++ b/modules/compiler_vm/languages/server/clang99.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/cpp.pm
+++ b/modules/compiler_vm/languages/server/cpp.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/freebasic.pm
+++ b/modules/compiler_vm/languages/server/freebasic.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/haskell.pm
+++ b/modules/compiler_vm/languages/server/haskell.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/java.pm
+++ b/modules/compiler_vm/languages/server/java.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/qbasic.pm
+++ b/modules/compiler_vm/languages/server/qbasic.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/server/tendra.pm
+++ b/modules/compiler_vm/languages/server/tendra.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/sh.pm
+++ b/modules/compiler_vm/languages/sh.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compiler_vm/languages/tendra.pm
+++ b/modules/compiler_vm/languages/tendra.pm
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/compliment
+++ b/modules/compliment
@@ -1,2 +1,6 @@
 #!/bin/sh
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 ~/pbot/modules/lookupbot.pl compliment $*

--- a/modules/cstd.pl
+++ b/modules/cstd.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/define.pl
+++ b/modules/define.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # quick and dirty by :pragma
 
 use LWP::Simple;

--- a/modules/dice_roll.pl
+++ b/modules/dice_roll.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # quick and dirty by :pragma
 
 use Games::Dice qw/roll roll_array/;

--- a/modules/excuse.sh
+++ b/modules/excuse.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 #host=bofh.jeffballard.us
 #port=666
 #grep excuse < /dev/tcp/$host/$port | sed 's/Your excuse is: //'

--- a/modules/expand_macros.pl
+++ b/modules/expand_macros.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # use warnings;
 use strict;
 use feature "switch";

--- a/modules/fnord.pl
+++ b/modules/fnord.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/funnyish_quote.pl
+++ b/modules/funnyish_quote.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Quick and dirty by :pragma
 
 use LWP::UserAgent;

--- a/modules/g.pl
+++ b/modules/g.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/gdefine.pl
+++ b/modules/gdefine.pl
@@ -1,4 +1,8 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
  
 # quick and dirty by :pragma
  

--- a/modules/gen_cfacts.pl
+++ b/modules/gen_cfacts.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # quick and dirty
 
 use warnings;

--- a/modules/gencstd.pl
+++ b/modules/gencstd.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # ugly and hacked together 
 
 use warnings;

--- a/modules/get_title.pl
+++ b/modules/get_title.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Quick and dirty by :pragma
 
 use LWP::UserAgent;

--- a/modules/getcfact.pl
+++ b/modules/getcfact.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/google.pl
+++ b/modules/google.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Quick and dirty by :pragma
 
 use LWP::UserAgent;

--- a/modules/gspy.pl
+++ b/modules/gspy.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use LWP::Simple;
 
 my $html;

--- a/modules/gtop10.pl
+++ b/modules/gtop10.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use LWP::Simple;
 
 my $html;

--- a/modules/gtop15.pl
+++ b/modules/gtop15.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use LWP::Simple;
 
 my $html;

--- a/modules/headlines.pl
+++ b/modules/headlines.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use XML::RSS;
 use LWP::Simple;
 

--- a/modules/horoscope
+++ b/modules/horoscope
@@ -1,2 +1,6 @@
 #!/bin/sh
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 ~/pbot/modules/lookupbot.pl horoscope $*

--- a/modules/horrorscope
+++ b/modules/horrorscope
@@ -1,2 +1,6 @@
 #!/bin/sh
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 ~/pbot/modules/lookupbot.pl horrorscope $*

--- a/modules/ideone.pl
+++ b/modules/ideone.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # use warnings;
 use strict;
 use feature qw(switch);

--- a/modules/insult.pl
+++ b/modules/insult.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/
-#
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use strict;
 use LWP::Simple;
  

--- a/modules/love_quote.pl
+++ b/modules/love_quote.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0 -I /home/msmud/lib/perl5/
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Quick and dirty by :pragma
 
 use LWP::UserAgent::WithCache;

--- a/modules/man.pl
+++ b/modules/man.pl
@@ -1,4 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/libwww-perl-5.808/lib
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # quick and dirty by :pragma
 
 use LWP::Simple;

--- a/modules/map.pl
+++ b/modules/map.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use LWP::Simple;
 
 my ($text, $buffer, $location);

--- a/modules/math.pl
+++ b/modules/math.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Quick and dirty by :pragma
 
 use Math::Units qw(convert);

--- a/modules/prototype.pl
+++ b/modules/prototype.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # quick and dirty by :pragma
 
 use strict;

--- a/modules/qalc.pl
+++ b/modules/qalc.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use warnings;
 use strict;
 

--- a/modules/random_quote.pl
+++ b/modules/random_quote.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w -I /home/msmud/lib/lib/perl5/site_perl/5.10.0 -I /home/msmud/lib/perl5/
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 # Quick and dirty by :pragma
 
 use LWP::UserAgent::WithCache;

--- a/modules/seen.pl
+++ b/modules/seen.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -w
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use strict;
 
 if($#ARGV != 0)

--- a/modules/urban
+++ b/modules/urban
@@ -1,2 +1,6 @@
 #!/bin/sh
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 ~/pbot/modules/lookupbot.pl urban $*

--- a/modules/weather.pl
+++ b/modules/weather.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -I /home/msmud/lib/lib/perl5/site_perl/5.10.0/ 
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use LWP::Simple;
 
 my ($text, $weather, $location, $date, $i, $day, @days);

--- a/modules/wikipedia.pl
+++ b/modules/wikipedia.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/perl -I /home/msmud/lib/perl5
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use strict;
 use WWW::Wikipedia;
 use Text::Autoformat;

--- a/pbot.pl
+++ b/pbot.pl
@@ -6,6 +6,10 @@
 # Purpose: IRC Bot (3rd generation)
 ########################
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 my $VERSION = "1.0.0";
 
 use strict;

--- a/pbot.sh
+++ b/pbot.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 mv log/log log/log-`date +%Y%m%d-%H:%M.%N` 2> /dev/null
 perl pbot.pl 2>> log/log


### PR DESCRIPTION
This patch adds the file LICENSE which is the verbatim copy of the
Mozilla Public License Version 2.0 as retreived from
https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt on
2017-03-05.

This patch also places license headers for the MPL2 type A variant of
the license header in the following files:

PBot/AntiFlood.pm
PBot/BanTracker.pm
PBot/BlackList.pm
PBot/BotAdminCommands.pm
PBot/BotAdmins.pm
PBot/ChanOpCommands.pm
PBot/ChanOps.pm
PBot/Channels.pm
PBot/Commands.pm
PBot/DualIndexHashObject.pm
PBot/EventDispatcher.pm
PBot/FactoidCommands.pm
PBot/FactoidModuleLauncher.pm
PBot/Factoids.pm
PBot/HashObject.pm
PBot/IRCHandlers.pm
PBot/IgnoreList.pm
PBot/IgnoreListCommands.pm
PBot/Interpreter.pm
PBot/LagChecker.pm
PBot/Logger.pm
PBot/MessageHistory.pm
PBot/MessageHistory_SQLite.pm
PBot/NickList.pm
PBot/PBot.pm
PBot/Plugins.pm
PBot/Plugins/AntiAway.pm
PBot/Plugins/AntiKickAutoRejoin.pm
PBot/Plugins/AntiRepeat.pm
PBot/Plugins/AntiTwitter.pm
PBot/Plugins/AutoRejoin.pm
PBot/Plugins/Counter.pm
PBot/Plugins/Quotegrabs.pm
PBot/Plugins/Quotegrabs/Quotegrabs_Hashtable.pm
PBot/Plugins/Quotegrabs/Quotegrabs_SQLite.pm
PBot/Plugins/UrlTitles.pm
PBot/Plugins/_Example.pm
PBot/Refresher.pm
PBot/Registerable.pm
PBot/Registry.pm
PBot/RegistryCommands.pm
PBot/SQLiteLogger.pm
PBot/SQLiteLoggerLayer.pm
PBot/SelectHandler.pm
PBot/StdinReader.pm
PBot/Timer.pm
PBot/Utils/ParseDate.pm
PBot/VERSION.pm
build/update-version.pl
modules/acronym.pl
modules/ago.pl
modules/c11std.pl
modules/c2english.pl
modules/c2english/CGrammar.pm
modules/c2english/c2eng.pl
modules/c99std.pl
modules/cdecl.pl
modules/cfaq.pl
modules/cjeopardy/IRCColors.pm
modules/cjeopardy/QStatskeeper.pm
modules/cjeopardy/Scorekeeper.pm
modules/cjeopardy/cjeopardy.pl
modules/cjeopardy/cjeopardy_answer.pl
modules/cjeopardy/cjeopardy_filter.pl
modules/cjeopardy/cjeopardy_hint.pl
modules/cjeopardy/cjeopardy_qstats.pl
modules/cjeopardy/cjeopardy_scores.pl
modules/cjeopardy/cjeopardy_show.pl
modules/codepad.pl
modules/compiler_block.pl
modules/compiler_client.pl
modules/compiler_vm/Diff.pm
modules/compiler_vm/cc
modules/compiler_vm/compiler_client.pl
modules/compiler_vm/compiler_server.pl
modules/compiler_vm/compiler_server_vbox_win32.pl
modules/compiler_vm/compiler_server_watchdog.pl
modules/compiler_vm/compiler_vm_client.pl
modules/compiler_vm/compiler_vm_server.pl
modules/compiler_vm/compiler_watchdog.pl
modules/compiler_vm/languages/_c_base.pm
modules/compiler_vm/languages/_default.pm
modules/compiler_vm/languages/bash.pm
modules/compiler_vm/languages/bc.pm
modules/compiler_vm/languages/bf.pm
modules/compiler_vm/languages/c11.pm
modules/compiler_vm/languages/c89.pm
modules/compiler_vm/languages/c99.pm
modules/compiler_vm/languages/clang.pm
modules/compiler_vm/languages/clang11.pm
modules/compiler_vm/languages/clang89.pm
modules/compiler_vm/languages/clang99.pm
modules/compiler_vm/languages/clangpp.pm
modules/compiler_vm/languages/clisp.pm
modules/compiler_vm/languages/cpp.pm
modules/compiler_vm/languages/freebasic.pm
modules/compiler_vm/languages/go.pm
modules/compiler_vm/languages/haskell.pm
modules/compiler_vm/languages/java.pm
modules/compiler_vm/languages/javascript.pm
modules/compiler_vm/languages/ksh.pm
modules/compiler_vm/languages/lua.pm
modules/compiler_vm/languages/perl.pm
modules/compiler_vm/languages/python.pm
modules/compiler_vm/languages/python3.pm
modules/compiler_vm/languages/qbasic.pm
modules/compiler_vm/languages/scheme.pm
modules/compiler_vm/languages/server/_c_base.pm
modules/compiler_vm/languages/server/_default.pm
modules/compiler_vm/languages/server/c11.pm
modules/compiler_vm/languages/server/c89.pm
modules/compiler_vm/languages/server/c99.pm
modules/compiler_vm/languages/server/clang.pm
modules/compiler_vm/languages/server/clang11.pm
modules/compiler_vm/languages/server/clang89.pm
modules/compiler_vm/languages/server/clang99.pm
modules/compiler_vm/languages/server/cpp.pm
modules/compiler_vm/languages/server/freebasic.pm
modules/compiler_vm/languages/server/haskell.pm
modules/compiler_vm/languages/server/java.pm
modules/compiler_vm/languages/server/qbasic.pm
modules/compiler_vm/languages/server/tendra.pm
modules/compiler_vm/languages/sh.pm
modules/compiler_vm/languages/tendra.pm
modules/compliment
modules/cstd.pl
modules/define.pl
modules/dice_roll.pl
modules/excuse.sh
modules/expand_macros.pl
modules/fnord.pl
modules/funnyish_quote.pl
modules/g.pl
modules/gdefine.pl
modules/gen_cfacts.pl
modules/gencstd.pl
modules/get_title.pl
modules/getcfact.pl
modules/google.pl
modules/gspy.pl
modules/gtop10.pl
modules/gtop15.pl
modules/headlines.pl
modules/horoscope
modules/horrorscope
modules/ideone.pl
modules/insult.pl
modules/love_quote.pl
modules/man.pl
modules/map.pl
modules/math.pl
modules/prototype.pl
modules/qalc.pl
modules/random_quote.pl
modules/seen.pl
modules/urban
modules/weather.pl
modules/wikipedia.pl
pbot.pl
pbot.sh

It is highly recommended that this list of files is reviewed to ensure
that all files are the copyright of the sole maintainer of the
repository. If any files with license headers contain the intellectual
property of anyone else, it is recommended that a request is made to
revise this patch or that the explicit permission of the co-author is
gained to allow for the license of the work to be changed.

I (Tomasz Kramkowski), the contributor, take no responsibility for any
legal action taken against the maintainer of this repository for
incorrectly claiming copyright to any work not owned by the maintainer
of this repository.