### PR TITLE
Make mute argument ordering consistent

### DIFF
--- a/PBot/ChanOpCommands.pm
+++ b/PBot/ChanOpCommands.pm
@@ -207,16 +207,33 @@ sub mute_user {
 sub unmute_user {
   my $self = shift;
   my ($from, $nick, $user, $host, $arguments) = @_;
+  my ($victim, $channel);
 
   if (not defined $from) {
     $self->{pbot}->{logger}->log("Command missing ~from parameter!\n");
     return "";
   }
 
-  my ($target, $channel) = split /\s+/, $arguments;
+  if (not $from =~ /^#/) {
+    # used in private message
+    if (not $arguments =~ s/^(#\S+)\s+(\S+)\s*//) {
+      return "/msg $nick Usage from private message: unmute <channel> <mask>";
+    }
+    ($channel, $victim) = ($1, $2);
+  } else {
+    # used in channel
+    if ($arguments =~ s/^(#\S+)\s+(\S+)\s*//) {
+      ($channel, $victim) = ($1, $2);
+    } elsif ($arguments =~ s/^(\S+)\s*//) {
+      ($channel, $victim) = ($from, $1);
+    } else {
+      return "/msg $mask Usage: unmute [channel] <mask>";
+    }
+  }
 
-  if (not defined $target) {
-    return "/msg $nick Usage: unmute <mask> [channel]";
+
+  if (not defined $victim) {
+    return "/msg $nick Usage: unmute [channel] <mask>";
   }
 
   $channel = $from if not defined $channel;
@@ -227,8 +244,8 @@ sub unmute_user {
     return "/msg $nick You are not an admin for $channel.";
   }
 
-  $self->{pbot}->{chanops}->unmute_user($target, $channel, 1);
-  return "/msg $nick $target has been unmuted in $channel.";
+  $self->{pbot}->{chanops}->unmute_user($victim, $channel, 1);
+  return "/msg $nick $victim has been unmuted in $channel.";
 }
 
 sub kick_user {

--- a/PBot/ChanOpCommands.pm
+++ b/PBot/ChanOpCommands.pm
@@ -144,7 +144,7 @@ sub mute_user {
   if (not $from =~ /^#/) {
     # used in private message
     if (not $arguments =~ s/^(#\S+)\s+(\S+)\s*(\S+|)//) {
-      return "/msg $mask Usage from private message: mute <channel> <nick> [timeout (default: 24 hours)]";
+      return "/msg $mask Usage from private message: mute <channel> <mask> [timeout (default: 24 hours)]";
     }
     ($channel, $victim, $length) = ($1, $2, $3);
   } else {
@@ -154,12 +154,12 @@ sub mute_user {
     } elsif ($arguments =~ s/^(\S+)\s*//) {
       ($channel, $victim) = ($from, $1);
     } else {
-      return "/msg $mask Usage: mute [channel] <nick> [timeout (default: 24 hours)]";
+      return "/msg $mask Usage: mute [channel] <mask> [timeout (default: 24 hours)]";
     }
   }
 
   if (not defined $channel and $from !~ m/^#/) {
-    return "/msg $mask Usage from private message: mute <channel> <nick> [timeout (default: 24 hours)]";
+    return "/msg $mask Usage from private message: mute <channel> <mask> [timeout (default: 24 hours)]";
   }
 
   if ($channel !~ m/^#/) {
@@ -175,7 +175,7 @@ sub mute_user {
   }
 
   if (not defined $victim) {
-    return "/msg $mask Usage: mute [channel] <nick> [timeout (default: 24 hours)]";
+    return "/msg $mask Usage: mute [channel] <mask> [timeout (default: 24 hours)]";
   }
 
   if (not defined $length) {

--- a/PBot/ChanOpCommands.pm
+++ b/PBot/ChanOpCommands.pm
@@ -133,8 +133,8 @@ sub unban_user {
 
 sub mute_user {
   my $self = shift;
-  my ($from, $mask, $user, $host, $arguments) = @_;
-  my  ($victim, $channel, $length);
+  my ($from, $nick, $user, $host, $arguments) = @_;
+  my ($victim, $channel, $length);
 
   if (not defined $from) {
     $self->{pbot}->{logger}->log("Command missing ~from parameter!\n");
@@ -144,7 +144,7 @@ sub mute_user {
   if (not $from =~ /^#/) {
     # used in private message
     if (not $arguments =~ s/^(#\S+)\s+(\S+)\s*(\S+|)//) {
-      return "/msg $mask Usage from private message: mute <channel> <mask> [timeout (default: 24 hours)]";
+      return "/msg $nick Usage from private message: mute <channel> <mask> [timeout (default: 24 hours)]";
     }
     ($channel, $victim, $length) = ($1, $2, $3);
   } else {
@@ -154,12 +154,12 @@ sub mute_user {
     } elsif ($arguments =~ s/^(\S+)\s*//) {
       ($channel, $victim) = ($from, $1);
     } else {
-      return "/msg $mask Usage: mute [channel] <mask> [timeout (default: 24 hours)]";
+      return "/msg $nick Usage: mute [channel] <mask> [timeout (default: 24 hours)]";
     }
   }
 
   if (not defined $channel and $from !~ m/^#/) {
-    return "/msg $mask Usage from private message: mute <channel> <mask> [timeout (default: 24 hours)]";
+    return "/msg $nick Usage from private message: mute <channel> <mask> [timeout (default: 24 hours)]";
   }
 
   if ($channel !~ m/^#/) {
@@ -175,7 +175,7 @@ sub mute_user {
   }
 
   if (not defined $victim) {
-    return "/msg $mask Usage: mute [channel] <mask> [timeout (default: 24 hours)]";
+    return "/msg $nick Usage: mute [channel] <mask> [timeout (default: 24 hours)]";
   }
 
   if (not defined $length) {
@@ -227,7 +227,7 @@ sub unmute_user {
     } elsif ($arguments =~ s/^(\S+)\s*//) {
       ($channel, $victim) = ($from, $1);
     } else {
-      return "/msg $mask Usage: unmute [channel] <mask>";
+      return "/msg $nick Usage: unmute [channel] <mask>";
     }
   }
 


### PR DESCRIPTION
Switch argument ordering so `mute` matches other ChanOp commands.
