### PR TITLE
compiler_vm: languages: change scheme to use guile

### DIFF
--- a/modules/compiler_vm/languages/scheme.pm
+++ b/modules/compiler_vm/languages/scheme.pm
@@ -16,7 +16,7 @@ sub initialize {
   $self->{sourcefile}      = 'prog.scm';
   $self->{execfile}        = 'prog.scm';
   $self->{default_options} = '';
-  $self->{cmdline}         = 'scm $options < $sourcefile';
+  $self->{cmdline}         = 'guile $options $sourcefile';
 
   $self->{cmdline_opening_comment} = "#|=============== CMDLINE ===============\n";
   $self->{cmdline_closing_comment} = "================= CMDLINE ===============|#\n";


### PR DESCRIPTION
The compiler vm doesn't have a scheme interpreter named "scm" but it
does have a scheme interpreter named "guile". Change the compiler_vm to
use the guile interpreter program instead of scm.