### PR TITLE
Fix stuff

### DIFF
--- a/PBot/Factoids.pm
+++ b/PBot/Factoids.pm
@@ -803,7 +803,7 @@ sub interpreter {
   #$self->{pbot}->{logger}->log("calling find_factoid in Factoids.pm, interpreter() to search for factoid against global/current\n");
   my ($channel, $keyword) = $self->find_factoid($stuff->{ref_from} ? $stuff->{ref_from} : $stuff->{from}, $stuff->{keyword}, $stuff->{arguments}, 1);
 
-  if (not $stuff->{ref_from} or $stuff->{ref_from} eq '.*') {
+  if (not $stuff->{ref_from} or $stuff->{ref_from} eq '.*' or $stuff->{ref_from} eq $stuff->{from}) {
     $stuff->{ref_from} = "";
   }
 

--- a/PBot/Interpreter.pm
+++ b/PBot/Interpreter.pm
@@ -293,7 +293,6 @@ sub interpret {
   $stuff->{nickoverride} = $stuff->{nick} if defined $stuff->{nickoverride} and lc $stuff->{nickoverride} eq 'me';
 
   if ($keyword !~ /^(?:factrem|forget|set|factdel|factadd|add|factfind|find|factshow|show|forget|factdel|factset|factchange|change|msg|tell|cc|eval|u|udict|ud|actiontrigger|urban|perl|ban|mute|spinach|choose|c|lie|l|adminadd|unmute|unban)$/) {
-    $keyword =~ s/(\w+)([?!.]+)$/$1/;
     $arguments =~ s/(?<![\w\/\-\\])i am\b/$stuff->{nick} is/gi if defined $arguments && $stuff->{interpret_depth} <= 2;
     $arguments =~ s/(?<![\w\/\-\\])me\b/$stuff->{nick}/gi if defined $arguments && $stuff->{interpret_depth} <= 2;
     $arguments =~ s/(?<![\w\/\-\\])my\b/$stuff->{nick}'s/gi if defined $arguments && $stuff->{interpret_depth} <= 2;


### PR DESCRIPTION
This PR fixes two things:

### fact

Using the `fact` command to call a factoid that exists in the channel the command was issued in would prepend the channel name to the output.

### punctuation

Punctuation at the end of a factoid name would cause normal factoid invocation to fail, but `fact` would work fine.