### PR TITLE
Fix broken ,fact behavior

### DIFF
--- a/PBot/Factoids.pm
+++ b/PBot/Factoids.pm
@@ -803,7 +803,7 @@ sub interpreter {
   #$self->{pbot}->{logger}->log("calling find_factoid in Factoids.pm, interpreter() to search for factoid against global/current\n");
   my ($channel, $keyword) = $self->find_factoid($stuff->{ref_from} ? $stuff->{ref_from} : $stuff->{from}, $stuff->{keyword}, $stuff->{arguments}, 1);
 
-  if (not $stuff->{ref_from} or $stuff->{ref_from} eq '.*') {
+  if (not $stuff->{ref_from} or $stuff->{ref_from} eq '.*' or $stuff->{ref_from} eq $stuff->{from}) {
     $stuff->{ref_from} = "";
   }
 


### PR DESCRIPTION
Using ,fact to invoke a factoid in the same channel you're invoking from currently causes the channel name to be prepended to the result. This PR fixes that thing.