### PR TITLE
fix ,cc interwined comments loses first ; after //

### DIFF
--- a/modules/compiler_vm/languages/_c_base.pm
+++ b/modules/compiler_vm/languages/_c_base.pm
@@ -352,7 +352,7 @@ sub preprocess_code {
   $self->{code} =~ s/\s+$//;
   $self->{code} =~ s/;\s*;\n/;\n/gs;
   $self->{code} =~ s/;(\s*\/\*.*?\*\/\s*);\n/;$1/gs;
-  $self->{code} =~ s/;(\s*\/\/.*?\s*);\n/;$1/gs;
+  $self->{code} =~ s/;(\s*\/\/.*?\s*);\n/;$1;/gs;
   $self->{code} =~ s/(\{|})\n\s*;\n/$1\n/gs;
   $self->{code} =~ s/(?:\n\n)+/\n\n/g;
 


### PR DESCRIPTION
Seems to work on my on my `ccc`/jupyter setup as we discussed just now...