### PR TITLE
compiler_vm: fix leading whitespace in $func_regex

### DIFF
--- a/modules/compiler_vm/languages/_c_base.pm
+++ b/modules/compiler_vm/languages/_c_base.pm
@@ -237,7 +237,7 @@ sub preprocess_code {
 
   print "looking for functions, has main: $has_main\n" if $self->{debug} >= 2;
 
-  my $func_regex = qr/^([ *\w]+)\s+([ ()*\w:\\]+)\s*\(([^;{]*)\s*\)\s*(\{.*|<%.*|\?\?<.*)/ims;
+  my $func_regex = qr/^\s*([ *\w]+)\s+([ ()*\w:\\]+)\s*\(([^;{]*)\s*\)\s*(\{.*|<%.*|\?\?<.*)/ims;
 
   # look for potential functions to extract
   while($preprecode =~ /$func_regex/ms) {


### PR DESCRIPTION
Fixes the issue where a function has a trailing whitespace before a line
break.

example:
```
void foo(){} 
int main(){return 0;}
```