### PR TITLE
compiler_vm: C removed unnecessary regex replace

### DIFF
--- a/modules/compiler_vm/languages/_c_base.pm
+++ b/modules/compiler_vm/languages/_c_base.pm
@@ -355,8 +355,6 @@ sub preprocess_code {
   $self->{code} =~ s/^\s+//;
   $self->{code} =~ s/\s+$//;
   $self->{code} =~ s/;\s*;\n/;\n/gs;
-  $self->{code} =~ s/;(\s*\/\*.*?\*\/\s*);\n/;$1/gs;
-  $self->{code} =~ s/;(\s*\/\/.*?\s*);\n/;$1;/gs;
   $self->{code} =~ s/(\{|})\n\s*;\n/$1\n/gs;
   $self->{code} =~ s/(?:\n\n)+/\n\n/g;
 


### PR DESCRIPTION
This problem has previously been encountered. And my last solution was
not satisfactory.

It seems like there were 2 regex lines, one targeting `//` and another
targeting `/* */`.

Originally they were basically meant to perform this:

Search for

```c
;<COMMENT>;\n
```

and replacing it with

```c
;<COMMENT>
```

In e00ba2e62fd4a72b9c1ac94894c2279884e55b60 I provided a patch to add
another `;` for `//` as it would eat the first `;` after the `<COMMENT>`

After thinking for some time, I came to the conclusion that the lines of
REGEX serve no purpose and should be removed.

For future reference:

e00ba2e62fd4a72b9c1ac94894c2279884e55b60 was targeting this problem:

```c
printf("why is the last ; missing?"); // foo \n int a=42;
```

which generated something along the lines of

```c
    printf("why is the last ; missing?");
// foo
    int a = 42return 0;
```

Where it would strip a `;` from the first line after a `//` comment

And this commit additionally targeted:

```c
printf("foo\n");
//printf("bar\n");
printf("baz\n");
// only happens if the line ends with ; eg:
printf("hello\n");
// deny with ;
printf("world\n");
```
output:

    foo
    hello

expected:

    foo
    baz
    hello
    world

where it generated the code:

```c
    printf("foo\n");
//printf("bar\n" );printf("baz\n" );
// only happens if the line ends with ; eg:
    printf("hello\n");
// deny with ;printf("world\n" );
```

Thus this should fix #62 and the original problem