### PR TITLE
Change "factoid" to "fact" in the user interface

### DIFF
--- a/lib/PBot/Core/Commands/Help.pm
+++ b/lib/PBot/Core/Commands/Help.pm
@@ -19,7 +19,7 @@ sub cmd_help {
     my ($self, $context) = @_;
 
     if (not length $context->{arguments}) {
-        return "For general help, see <https://github.com/pragma-/pbot/tree/master/doc>. For help about a specific command or factoid, use `help <keyword> [channel]`.";
+        return "For general help, see <https://github.com/pragma-/pbot/tree/master/doc>. For help about a specific command or fact, use `help <keyword> [channel]`.";
     }
 
     my $keyword = lc $self->{pbot}->{interpreter}->shift_arg($context->{arglist});


### PR DESCRIPTION
Nitpicky and minor fix. Feel free to discard if annoying.

While the concept that the term "factoid" refers to a small/trivial fact is popular, and the English language evolves whether or not dictionary-writers chime in, the word is still ambiguous as it could potentially, and often does, refer to an untruth cited as a fact.

It would harm nobody to *not* change this, I'm just submitting this PR to make this change easy if you *would* like to consider changing it. This does not affect documentation, simply a user-facing message.