### PR TITLE
applets/paren: Disambiguate `*f(x)` = `*(f(x))` from `(*f)(x)`

### DIFF
--- a/applets/paren/paren.py
+++ b/applets/paren/paren.py
@@ -47,7 +47,7 @@ class CGenerator(c_generator.CGenerator):
                 return 'sizeof %s' % self._parenthesize_unless_simple(n.expr)
         else:
             operand = self.visit(n.expr)
-            if isinstance(n.expr, c_ast.ArrayRef) or not self._is_simple_node(n.expr):
+            if not self._is_simple_node(n.expr) or (n.op == '*' and isinstance(n.expr, c_ast.FuncCall)):
                 operand = '(%s)' % operand
             if n.op in ('p++', 'p--'):
                 return operand + n.op[1:]


### PR DESCRIPTION
Also remove the explicit check for `ArrayRef`, which is obsolete since the 2014 addition of the `_is_simple_node` override in commit ba59edb04. (Upstream `_is_simple_node` returns `True` for an `ArrayRef`.)